### PR TITLE
 Bug Fix: The Property 'AudioQuality' can be null on 'not available' …

### DIFF
--- a/AthamePlugin.Tidal/InternalApi/MetadataHelpers.cs
+++ b/AthamePlugin.Tidal/InternalApi/MetadataHelpers.cs
@@ -22,14 +22,14 @@ namespace AthamePlugin.Tidal.InternalApi
             };
         }
 
-        public static Metadata MasterMetadata(StreamingQuality quality)
+        public static Metadata MasterMetadata(StreamingQuality? quality)
         {
             return new Metadata
             {
                 CanDisplay = true,
                 IsFlag = true,
                 Name = "Master",
-                Value = (quality == StreamingQuality.HiRes).ToString()
+                Value = quality.HasValue ? (quality.Value == StreamingQuality.HiRes).ToString() : "Undefined"
             };
         }
     }

--- a/AthamePlugin.Tidal/InternalApi/Models/TidalTrack.cs
+++ b/AthamePlugin.Tidal/InternalApi/Models/TidalTrack.cs
@@ -66,7 +66,8 @@ namespace AthamePlugin.Tidal.InternalApi.Models
         public bool Explicit { get; set; }
 
         [JsonProperty("audioQuality")]
-        public StreamingQuality AudioQuality { get; set; }
+        // Can be null on 'not available' tracks (those tracks are market gray on tidal playlists i.e.)
+        public StreamingQuality? AudioQuality { get; set; }
 
         [JsonProperty("artist")]
         public FeaturedArtist Artist { get; set; }
@@ -79,6 +80,7 @@ namespace AthamePlugin.Tidal.InternalApi.Models
 
         internal Track CreateAthameTrack(TidalServiceSettings settings)
         {
+
             // Always put main artists in the artist field
             var t = new Track
             {
@@ -96,7 +98,7 @@ namespace AthamePlugin.Tidal.InternalApi.Models
                 }
             };
 
-            
+
 
             // If the featured artists aren't already in the title, append them there
             if (!EnglishArtistNameJoiner.DoesTitleContainArtistString(this))


### PR DESCRIPTION
…tracks (those tracks are market gray on tidal playlists i.e.)

**Exception on submitting a playlist:**
```
[Window Title]
Athame

[Main Instruction]
An error occurred while trying to retrieve information for this media.

[Content]
The provided URL may be invalid or unsupported.

[^] Hide details  [Break into debugger] [OK]

[Expanded Information]
JsonSerializationException: Cannot convert null value to AthamePlugin.Tidal.InternalApi.Models.StreamingQuality. Path 'audioQuality'.
--- Begin stack trace ---
   at Newtonsoft.Json.Converters.StringEnumConverter.ReadJson(JsonReader reader, Type objectType, Object existingValue, JsonSerializer serializer)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.DeserializeConvertable(JsonConverter converter, JsonReader reader, Type objectType, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.SetPropertyValue(JsonProperty property, JsonConverter propertyConverter, JsonContainerContract containerContract, JsonProperty containerProperty, JsonReader reader, Object target)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.PopulateObject(Object newObject, JsonReader reader, JsonObjectContract contract, JsonProperty member, String id)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateObject(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.CreateValueInternal(JsonReader reader, Type objectType, JsonContract contract, JsonProperty member, JsonContainerContract containerContract, JsonProperty containerMember, Object existingValue)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalReader.Deserialize(JsonReader reader, Type objectType, Boolean checkAdditionalContent)
   at Newtonsoft.Json.JsonSerializer.DeserializeInternal(JsonReader reader, Type objectType)
   at Newtonsoft.Json.Linq.JToken.ToObject(Type objectType, JsonSerializer jsonSerializer)
   at Newtonsoft.Json.Linq.JToken.ToObject(Type objectType)
   at Newtonsoft.Json.Linq.JToken.ToObject[T]()
   at AthamePlugin.Tidal.InternalApi.PlaylistPageManager.<>c.<GetNextPageAsync>b__1_1(PageListItem playlistItem) in P:\Repos\AthamePlugin.Tidal\AthamePlugin.Tidal\InternalApi\PlaylistPageManager.cs:line 36
   at System.Linq.Enumerable.WhereSelectListIterator`2.MoveNext()
   at System.Collections.Generic.List`1..ctor(IEnumerable`1 collection)
   at System.Linq.Enumerable.ToList[TSource](IEnumerable`1 source)
   at AthamePlugin.Tidal.InternalApi.PlaylistPageManager.<GetNextPageAsync>d__1.MoveNext() in P:\Repos\AthamePlugin.Tidal\AthamePlugin.Tidal\InternalApi\PlaylistPageManager.cs:line 29
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Athame.PluginAPI.Service.PagedMethod`1.<LoadAllPagesAsync>d__15.MoveNext() in P:\Repos\Athame\Athame.PluginAPI\Service\PagedMethod.cs:line 57
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at AthamePlugin.Tidal.TidalService.<GetPlaylistAsync>d__11.MoveNext() in P:\Repos\AthamePlugin.Tidal\AthamePlugin.Tidal\TidalService.cs:line 120
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter`1.GetResult()
   at Athame.UI.MainForm.<>c__DisplayClass45_0.<<button1_Click>b__0>d.MoveNext() in P:\Repos\Athame\Athame\
```