### PR TITLE
Add Support for Downloading All Albums of an Artist for Tidal

### DIFF
--- a/AthamePlugin.Tidal/AthameAlbumPagedMethod.cs
+++ b/AthamePlugin.Tidal/AthameAlbumPagedMethod.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Athame.PluginAPI.Service;
+using AthamePlugin.Tidal.InternalApi.Models;
+
+namespace AthamePlugin.Tidal
+{
+    public class AthameAlbumPagedMethod : PagedMethod<Album>
+    {
+        private PagedMethod<TidalAlbum> albumsPagedMethod;
+        private TidalServiceSettings settings;
+
+        public AthameAlbumPagedMethod(TidalServiceSettings settings, PagedMethod<TidalAlbum> albumsPagedMethod) : base(albumsPagedMethod.ItemsPerPage)
+        {
+            this.albumsPagedMethod = albumsPagedMethod;
+            this.settings = settings;
+        }
+
+        public override async Task<IList<Album>> GetNextPageAsync()
+        {
+            var nextItems = await albumsPagedMethod.GetNextPageAsync();
+            return nextItems.Select(tidalAlbum => tidalAlbum.CreateAthameAlbum(settings)).ToList();
+        }
+
+        public override int ItemsPerPage => albumsPagedMethod.ItemsPerPage;
+
+        public override IList<Album> AllItems => albumsPagedMethod.AllItems.Select(tidalAlbum => tidalAlbum.CreateAthameAlbum(settings)).ToList();
+
+        public override bool HasMoreItems => albumsPagedMethod.HasMoreItems;
+
+        public override int TotalNumberOfItems => albumsPagedMethod.TotalNumberOfItems;
+
+        public override async Task LoadAllPagesAsync()
+        {
+            while (HasMoreItems)
+            {
+                await GetNextPageAsync();
+            }
+        }
+    }
+}

--- a/AthamePlugin.Tidal/AthamePlugin.Tidal.csproj
+++ b/AthamePlugin.Tidal/AthamePlugin.Tidal.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AthameAlbumPagedMethod.cs" />
     <Compile Include="AthameTrackPagedMethod.cs" />
     <Compile Include="Country.cs" />
     <Compile Include="InternalApi\Decryption\Aes128CounterMode.cs" />
@@ -108,7 +109,9 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <WCFMetadata Include="Connected Services\" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/AthamePlugin.Tidal/TidalService.cs
+++ b/AthamePlugin.Tidal/TidalService.cs
@@ -166,9 +166,13 @@ namespace AthamePlugin.Tidal
             throw new NotImplementedException();
         }
 
-        public override Task<Artist> GetArtistInfoAsync(string artistId)
+        public override async Task<Artist> GetArtistInfoAsync(string artistId)
         {
-            throw new NotImplementedException();
+            var artist = await client.GetArtistAsync(Int32.Parse(artistId));
+            return new Artist
+            {
+                Name = artist.Name
+            };
         }
 
         public override PagedMethod<Track> GetArtistTopTracks(string artistId, int itemsPerPage)
@@ -178,7 +182,8 @@ namespace AthamePlugin.Tidal
 
         public override PagedMethod<Album> GetArtistAlbums(string artistId, int itemsPerPage)
         {
-            throw new NotImplementedException();
+            var itemsPages = client.GetArtistAlbums(Int32.Parse(artistId));
+            return new AthameAlbumPagedMethod(settings, itemsPages);
         }
 
         public override async Task<Album> GetAlbumAsync(string albumId, bool withTracks)


### PR DESCRIPTION
By using (mostly) pre-existing code within the Tidal plugin, I added support for getting artist info, and more notably, support for listing albums of an artist. Most of this was already supported by the InternalApi, and I simply had to make that compatible with the Athame API (which I modified in another pull request).