### PR TITLE
Add Support for WiMP URLs

### DIFF
--- a/AthamePlugin.Tidal/TidalService.cs
+++ b/AthamePlugin.Tidal/TidalService.cs
@@ -27,6 +27,7 @@ namespace AthamePlugin.Tidal
         private TidalClient client;
         private TidalServiceSettings settings = new TidalServiceSettings();
         private const string TidalWebDomain = "listen.tidal.com";
+        private const string WimpWebDomain = "play.wimpmusic.com";
 
         public TidalService()
         {
@@ -266,6 +267,7 @@ namespace AthamePlugin.Tidal
             {
                 new Uri("http://" + TidalWebDomain), new Uri("https://" + TidalWebDomain),
                 new Uri("http://tidal.com"), new Uri("https://tidal.com"),
+                new Uri("http://" + WimpWebDomain), new Uri("https://" + WimpWebDomain),
             };
 
 


### PR DESCRIPTION
This is a small fix to include support for WiMP (which is the light theme of Tidal) URLs.